### PR TITLE
[feat] 로그아웃 기능, 유저 정보 fetch, not found 페이지 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.76.1",
+    "axios": "^1.9.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.510.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.76.1
         version: 5.76.1(react@19.1.0)
+      axios:
+        specifier: ^1.9.0
+        version: 1.9.0
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -1130,6 +1133,9 @@ packages:
     resolution: {integrity: sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==}
     engines: {node: '>=4'}
 
+  axios@1.9.0:
+    resolution: {integrity: sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==}
+
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
@@ -1777,6 +1783,15 @@ packages:
 
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
+
+  follow-redirects@1.15.9:
+    resolution: {integrity: sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
 
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
@@ -2897,6 +2912,9 @@ packages:
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
   psl@1.15.0:
     resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
@@ -4652,6 +4670,14 @@ snapshots:
 
   axe-core@4.10.3: {}
 
+  axios@1.9.0:
+    dependencies:
+      follow-redirects: 1.15.9
+      form-data: 4.0.2
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+
   axobject-query@4.1.0: {}
 
   babel-jest@29.7.0(@babel/core@7.27.1):
@@ -5478,6 +5504,8 @@ snapshots:
       keyv: 4.5.4
 
   flatted@3.3.3: {}
+
+  follow-redirects@1.15.9: {}
 
   for-each@0.3.5:
     dependencies:
@@ -6706,6 +6734,8 @@ snapshots:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
+
+  proxy-from-env@1.1.0: {}
 
   psl@1.15.0:
     dependencies:

--- a/src/app/api/auth/fetch-user/route.ts
+++ b/src/app/api/auth/fetch-user/route.ts
@@ -1,0 +1,22 @@
+import axios, { AxiosError } from 'axios';
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(req: NextRequest) {
+    const { token } = await req.json();
+
+    try {
+        const response = await axios.get(
+            `${process.env.API_URI_DEV}/auths/user`,
+            {
+                params: { teamId: `${process.env.TEAM_ID_DEV}` },
+                headers: {
+                    Authorization: `Bearer ${token}`,
+                },
+            }
+        );
+        return new NextResponse(JSON.stringify(response.data), { status: 200 });
+    } catch (error) {
+        const err = error as AxiosError;
+        return new NextResponse(JSON.stringify({ error: err?.response?.data }), { status: 500 });
+    }
+}

--- a/src/app/api/auth/signout/route.ts
+++ b/src/app/api/auth/signout/route.ts
@@ -1,16 +1,15 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import axios, { AxiosError } from 'axios';
 
-export async function POST(req: NextRequest) {
-    const { email, password } = await req.json();
+export async function POST() {
     try {
-        const response = await axios.post(`${process.env.API_URI_DEV}/auths/signin`, {
-            email,
-            password
-        })
+        const response = await axios.post(`${process.env.API_URI_DEV}/auths/signout`,
+            `${process.env.API_URI_DEV}`
+        )
         return new NextResponse(JSON.stringify(response.data), { status: 200 });
     } catch (error) {
         const err = error as AxiosError;
         return new NextResponse(JSON.stringify({ error: err?.response?.data }), { status: 500 });
     }
 }
+

--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -4,7 +4,7 @@ import axios, { AxiosError } from 'axios';
 export async function POST(req: NextRequest) {
     const { email, password, name, companyName } = await req.json();
     try {
-        const response = await axios.post(`${process.env.NEXT_PUBLIC_API_URI_DEV}/auths/signup`, {
+        const response = await axios.post(`${process.env.API_URI_DEV}/auths/signup`, {
             email,
             password,
             name,

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,13 @@
+export default function NotFound() {
+  return (
+    <div className="min-h-screen w-screen flex items-center justify-center">
+      <div className="text-center p-8">
+        <h1 className="text-6xl font-bold text-gray-900 mb-4">잘못된 경로</h1>
+        <p className="flex flex-col text-xl text-gray-600">
+          <span>요청하신 페이지를 찾을 수 없습니다.</span>
+          <span>페이지 상단의 다른 메뉴를 클릭하여 이동해 주세요.</span>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,8 +2,8 @@ export default function Home() {
   return (
     <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
       <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <p className="mb-2 tracking-[-.01em]">
-          안녕하세요 즐거운 개발 시작하세요! 테스트 중입니다...ㅁㄴㅇㄹㅁㄴㅇㄹㄴㅁㅇㄹ
+        <p className="mb-2 tracking-[-.01em] text-3xl font-bold">
+          밋밋 홈페이지 입니다
         </p>
       </main>
     </div>

--- a/src/components/auth/SigninForm.tsx
+++ b/src/components/auth/SigninForm.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useState } from 'react';
+import { useContext, useState } from 'react';
+import { AuthContext } from '@/providers/AuthProvider';
 import { regexEmail, regexPassword } from './shared/utils/vaildator';
-import { useRouter } from 'next/navigation';
 import axios from 'axios';
 import Image from 'next/image';
 import Link from 'next/link';
@@ -15,7 +15,9 @@ export default function SigninForm() {
     const [isPasswordVisible, setIsPasswordVisible] = useState(false);
     const [errorResponseMessage, setErrorResponseMessage] = useState<string | null>(null);
 
-    const router = useRouter();
+    const { signin } = useContext(AuthContext);
+
+
 
     const handlePasswordVisibility = (e: React.MouseEvent<HTMLButtonElement>) => {
         e.preventDefault();
@@ -51,23 +53,15 @@ export default function SigninForm() {
         }
 
         try {
-            const result = await axios.post('/api/auth/signin', { email, password });
-            if (result.status === 200) {
-                alert('로그인에 성공했습니다.')
-                localStorage.setItem('token', result.data.token);
-                router.replace('/');
-            }
+            await signin(email, password)
         } catch (error) {
             if (axios.isAxiosError(error)) {
                 const serverError = error?.response?.data?.error;
-                if (serverError) {
-                    setErrorResponseMessage(serverError.message);
-                } else {
-                    setErrorResponseMessage('로그인 처리 중 오류가 발생했습니다.');
-                }
+                if (serverError) setErrorResponseMessage(serverError.message);
+                else setErrorResponseMessage('로그인 처리 중 오류가 발생했습니다.');
             } else {
                 setErrorResponseMessage('알 수 없는 오류가 발생했습니다.');
-                console.error(error);
+                console.log(error);
             }
         }
     }
@@ -119,7 +113,9 @@ export default function SigninForm() {
                             onChange={handlePasswordChange}
                             required
                         />
-                        <button className='absolute right-2.5 top-1/4 cursor-pointer hover:opacity-60 transition-all duration-200 ease-in-out'
+                        <button
+                            type='button'
+                            className='absolute right-2.5 top-1/4 cursor-pointer hover:opacity-60 transition-all duration-200 ease-in-out'
                             onClick={handlePasswordVisibility}
                         >
                             <Image src={isPasswordVisible ? "/images/visibility_on.svg" : "/images/visibility_off.svg"} alt="비밀번호 보기 숨김" width={24} height={24} />

--- a/src/components/auth/SignupForm.tsx
+++ b/src/components/auth/SignupForm.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useState } from 'react';
-import { useRouter } from 'next/navigation';
+import { useContext, useState } from 'react';
 import { regexEmail, regexPassword } from './shared/utils/vaildator';
+import { AuthContext } from '@/providers/AuthProvider';
 import Image from 'next/image';
 import Link from 'next/link';
 import axios from 'axios';
@@ -23,7 +23,8 @@ export default function SignupForm() {
 
     const [errorResponseMessage, setErrorResponseMessage] = useState<string | null>(null);
 
-    const router = useRouter();
+    const { signup } = useContext(AuthContext)
+
 
     const handlePasswordVisibility = (e: React.MouseEvent<HTMLButtonElement>) => {
         e.preventDefault();
@@ -87,11 +88,7 @@ export default function SignupForm() {
         }
 
         try {
-            const result = await axios.post('/api/auth/signup', { email, password, name, companyName })
-            if (result.status === 200) {
-                alert('회원가입이 완료되었습니다.')
-                router.replace('/signin')
-            }
+            await signup(email, password, name, companyName);
         } catch (error) {
             if (axios.isAxiosError(error)) {
                 const serverError = error?.response?.data?.error;

--- a/src/components/shared/ui/Navbar.tsx
+++ b/src/components/shared/ui/Navbar.tsx
@@ -1,20 +1,18 @@
 'use client';
 
-import { useContext } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import { AuthContext } from '@/providers/AuthProvider';
-import { useRouter } from 'next/navigation';
 import Image from 'next/image';
 import Link from 'next/link';
 
 export default function Navbar() {
-    const { token } = useContext(AuthContext);
+    const [userName, setUserName] = useState('');
 
-    const router = useRouter();
+    const { token, signout } = useContext(AuthContext);
 
-    const handleSignout = () => {
-        localStorage.removeItem('token');
-        router.replace('/signin')
-    }
+    useEffect(() => {
+        setUserName(JSON.parse(localStorage.getItem('user_name') || '유저'));
+    }, [])
 
     return (
         <div
@@ -27,7 +25,7 @@ export default function Navbar() {
                         alt="logo image"
                         width={100}
                         height={100}
-                        className='w-[6rem] h-[6rem] hover:opacity-50 duration-300 ease-in-out'
+                        className='w-[6rem] h-[6rem] pointer-events-none'
                     />
                 </Link>
                 <Link href="/gatherings" className='hover:opacity-50 duration-300 ease-in-out'>모임찾기</Link>
@@ -35,11 +33,13 @@ export default function Navbar() {
                 <Link href='/reviews' className='hover:opacity-50 duration-300 ease-in-out'>모든 리뷰</Link>
             </div>
             <div className='flex items-center'>
-                {token ? (
-                    <button onClick={handleSignout} className='cursor-pointer hover:opacity-50 duration-300 ease-in-out'>로그아웃</button>
-                ) : (
-                    <Link href='/signin' className='hover:opacity-50 duration-300 ease-in-out'>로그인</Link>
+                {token && (
+                    <div className='flex items-center gap-2'>
+                        <span className='font-bold text-main-600'>{userName}</span>
+                        <button onClick={() => signout()} className='cursor-pointer hover:opacity-50 duration-300 ease-in-out'>로그아웃</button>
+                    </div>
                 )}
+                {!token && <Link href='/signin' className='hover:opacity-50 duration-300 ease-in-out'>로그인</Link>}
             </div>
         </div>
     );

--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -2,39 +2,114 @@
 
 import { usePathname, useRouter } from 'next/navigation';
 import { createContext, useState, Dispatch, SetStateAction, useEffect } from "react";
+import axios from 'axios';
 
 type AuthContextType = {
     token: string | null;
     setToken: Dispatch<SetStateAction<string | null>>;
+    signup: (email: string, password: string, name: string, companyName: string) => Promise<void>;
+    signin: (email: string, password: string) => Promise<void>;
+    signout: () => Promise<void>;
 };
 
 export const AuthContext = createContext<AuthContextType>({
     token: null,
-    setToken: () => { }
+    setToken: () => { },
+    signup: async () => { },
+    signin: async () => { },
+    signout: async () => { }
 });
 
 export default function AuthProvider({ children }: { children: React.ReactNode }) {
     const [token, setToken] = useState<string | null>(null);
+    const [isLoading, setIsLoading] = useState<boolean>(true);
+    const [previousPath, setPreviousPath] = useState<string>('/');
 
     const router = useRouter();
     const pathname = usePathname();
 
+    const signup = async (email: string, password: string, name: string, companyName: string) => {
+        try {
+            const result = await axios.post('/api/auth/signup', { email, password, name, companyName })
+            if (result.status === 200) {
+                alert('회원가입이 완료되었습니다.')
+                router.replace('/signin')
+            }
+        } catch (error) {
+            throw error;
+        }
+    }
+
+    const signin = async (email: string, password: string) => {
+        try {
+            const result = await axios.post('/api/auth/signin', { email, password });
+            if (result.status === 200) {
+                alert('로그인에 성공했습니다.')
+                localStorage.setItem('token', result.data.token);
+                setToken(result.data.token);
+                fetchUser(result.data.token);
+                router.replace('/');
+            }
+        } catch (error) {
+            throw error;
+        }
+    }
+
+    const fetchUser = async (token: string) => {
+        try {
+            const result = await axios.post('/api/auth/fetch-user', { token });
+            if (result.status === 200) {
+                console.log(result.data);
+                localStorage.setItem('user_name', JSON.stringify(result.data.name));
+                localStorage.setItem('user_id', JSON.stringify(result.data.id));
+                localStorage.setItem('user_company_name', JSON.stringify(result.data.companyName));
+                localStorage.setItem('user_image', JSON.stringify(result.data.image));
+            }
+        } catch (error) {
+            throw error;
+        }
+    }
+
+    const signout = async () => {
+        localStorage.removeItem('token');
+        setToken(null);
+        const result = await axios.post('/api/auth/signout');
+        if (result.status === 200) console.log('로그아웃에 성공했습니다.')
+    }
+
+    // 페이지 이동 시 토큰 감지
     useEffect(() => {
-        const token = localStorage.getItem('token');
-        if (token) setToken(token);
-    }, [token, setToken])
+        const initAuth = () => {
+            const storedToken = localStorage.getItem('token');
+            if (storedToken) setToken(storedToken);
+            setIsLoading(false);
+        };
+
+        initAuth();
+    }, []);
 
     useEffect(() => {
-        if (pathname.startsWith('/mypage') && !token) router.replace('/signin');
-    }, [pathname, token, router])
+        if (pathname !== '/signin' && !pathname.includes('/auth/')) {
+            setPreviousPath(pathname);
+            console.log('Previous path set to:', pathname);
+        }
+    }, [pathname]);
 
     useEffect(() => {
-        if (pathname === '/signin' && token) router.replace('/');
-    }, [pathname, token, router]);
+        if (!isLoading && !token && pathname.startsWith('/mypage')) {
+            console.log('AuthProvider: 로그인이 필요합니다.');
+            alert('로그인이 필요합니다.')
+            router.replace('/signin');
+        }
+
+        if (!isLoading && token && pathname === '/signin') {
+            router.replace(previousPath);
+        }
+    }, [isLoading, token, pathname, router, previousPath]);
 
     return (
-        <AuthContext value={{ token, setToken }}>
+        <AuthContext.Provider value={{ token, setToken, signup, signin, signout }}>
             {children}
-        </AuthContext>
+        </AuthContext.Provider>
     );
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,27 +1,47 @@
 {
   "compilerOptions": {
-    "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "target": "esnext",
+    "module": "esnext",
+    "jsx": "preserve",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
-    "noEmit": true,
     "esModuleInterop": true,
-    "module": "esnext",
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
     "incremental": true,
+    "noEmit": true,
+    "noImplicitAny": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": false,
+    "moduleDetection": "force",
     "plugins": [
       {
         "name": "next"
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": [
+        "./src/*"
+      ]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    ".next"
+  ]
 }


### PR DESCRIPTION
## 📌 타입스크립트 규칙 추가
• 선언했으나 사용하지 않은 변수 편집창에서 warn 표시 <br/>

## 📌 404 not-found 페이지 구현
• not-found.tsx <br/>

## 📌 로그아웃, 로그인 된 유저 정보 fetch 구현
• api/auth/signout, api/auth/fetch-user <br/>

## 📌 로그인과 회원가입 비동기 함수를 AuthProvider 내부로 이동

## 📌 네비게이션바 UI 업데이트 적용
- 비로그인/로그인에 따라 우상단 UI 로그인/닉네임, 로그아웃이 새로고침해야 적용되는 상황이었음
- 즉시 업데이트되도록 내부 상태 로직 변경하여 해결

## 📌 AuthProvider 내부 리다이렉션 로직 구현
• 비회원 마이페이지 접속 시도시 로그인 페이지로 리다이렉션
• 로그인 된 상태에서 로그인 페이지 접속 시도시 이전 페이지로 리다이렉션