### PR TITLE
[style] 공통 스타일 정의, 로그인 & 회원가입 폼 제출 버튼 disabled 수정

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,6 +7,13 @@
   /* 브레이크 포인트 */
   --breakpoint-sm: 375px;
   --breakpoint-md: 744px;
+  --breakpoint-lg: 1100px;
+
+  /* 폰트 */
+  --font-pretendard: var(--font-pretendard);
+
+  /* 폰트 사이즈 */
+  --text-2xs: 0.5rem;
 
   /* 컬러 */
   --color-white: oklch(1 0 0);
@@ -44,8 +51,26 @@
   --color-red-900: oklch(0.400 0.265 27.0);
   --color-red-950: oklch(0.350 0.265 27.0);
 
-  /* 폰트 */
-  --font-pretendard: var(--font-pretendard);
+  --color-global-text: var(--color-gray-900);
+
+  /* 전 페이지 공통 UI */
+  /* ---- 해당 버튼: 모임 만들기, 참여하기, 공유하기, 모달 '확인', 로그인, 회원가입 '확인' */
+  --color-button: var(--color-main-500);
+  --color-button-text: var(--color-white);
+  --color-button-disabled: var(--color-gray-400);
+  --color-button-hover: var(--color-main-600);
+
+  /* ---- 달램핏, 워케이션 대분류 버튼 텍스트 */
+  --color-button-categories-active: var(--color-gray-900);
+  --color-button-categories: var(--color-gray-400);
+
+  /* ---- 달램핏 소분류 버튼 텍스트, 배경색 */
+  --color-button-type-text: var(--color-white);
+  --color-button-type-bg: var(--color-gray-900);
+
+  /* --- 페이지별 헤딩 */
+  --color-heading: var(--color-gray-900);
+  --color-heading-description: var(--color-gray-700);
 }
 
 @theme inline {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -40,7 +40,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${pretendard.variable} font-pretendard`}
+        className={`${pretendard.variable} font-pretendard text-global-text`}
       >
         <Providers>
           <Navbar />

--- a/src/components/auth/AuthPoster.tsx
+++ b/src/components/auth/AuthPoster.tsx
@@ -2,7 +2,7 @@ import Image from 'next/image';
 
 export default function AuthPoster() {
     return (
-        <div className='flex lg:flex-col gap-2 items-center justify-center'>
+        <div className='flex flex-col sm:flex-row lg:flex-col gap-2 items-center justify-center'>
             <Image
                 src='/images/auth_background.avif'
                 alt='signin background poster'
@@ -12,8 +12,8 @@ export default function AuthPoster() {
             />
             <div>
                 <h2 className='mb-1 text-lg lg:text-2xl font-bold'>미리 계획하지 않아도 괜찮아요.</h2>
-                <p className='text-sm lg:text-base text-gray-600'>MeetMeet과 함께라면 언제든지, 어디서든지</p>
-                <p className='text-sm lg:text-base text-gray-600'>누구와도 의미 있는 만남을 시작할 수 있습니다.</p>
+                <p className='text-2xs sm:text-sm lg:text-base text-gray-600'>MeetMeet과 함께라면 언제든지, 어디서든지</p>
+                <p className='text-2xs sm:text-sm lg:text-base text-gray-600'>누구와도 의미 있는 만남을 시작할 수 있습니다.</p>
             </div>
         </div>
     );

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -26,6 +26,7 @@ export default function LoginForm() {
 
     const {
         register,
+        watch,
         handleSubmit,
         formState: { errors, isSubmitting, isSubmitted },
     } = useForm<SigninFormSchemaType>({
@@ -35,6 +36,9 @@ export default function LoginForm() {
             password: '12312!2a',
         },
     });
+
+    const email = watch('email');
+    const password = watch('password');
 
     const onSubmit = async (data: SigninFormSchemaType) => {
         setErrorResponseMessage(null);
@@ -86,6 +90,7 @@ export default function LoginForm() {
                     isSubmitting={isSubmitting}
                     isPasswordMatch={true}
                     text="로그인"
+                    props={{ email, password }}
                 />
                 <FormFooter
                     route="/register"

--- a/src/components/auth/RegisterForm.tsx
+++ b/src/components/auth/RegisterForm.tsx
@@ -39,6 +39,9 @@ export default function RegisterForm() {
         resolver: zodResolver(signupFormSchema),
     });
 
+    const name = watch('name');
+    const email = watch('email');
+    const companyName = watch('companyName');
     const password = watch('password');
 
     const onSubmit = async (data: SignupFormSchemaType) => {
@@ -139,6 +142,7 @@ export default function RegisterForm() {
                     isSubmitting={isSubmitting}
                     isPasswordMatch={isPasswordMatch}
                     text="확인"
+                    props={{ name, email, companyName, password }}
                 />
                 <FormFooter
                     route="/login"

--- a/src/components/auth/shared/ui/SubmitButton.tsx
+++ b/src/components/auth/shared/ui/SubmitButton.tsx
@@ -1,15 +1,21 @@
 interface SubmitButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
     isSubmitting: boolean;
-    isPasswordMatch?: boolean;
     text: string;
+    isPasswordMatch?: boolean;
+    props: {
+        name?: string;
+        email: string;
+        companyName?: string;
+        password: string;
+    }
 }
 
-export default function SubmitButton({ isSubmitting, isPasswordMatch, text }: SubmitButtonProps) {
+export default function SubmitButton({ isSubmitting, isPasswordMatch, text, props }: SubmitButtonProps) {
     return (
         <button
             type="submit"
-            disabled={isSubmitting || !isPasswordMatch}
-            className={`w-full rounded-lg ${isSubmitting || !isPasswordMatch ? 'bg-gray-400' : 'bg-main-300'} px-5 py-2.5 text-center text font-bold text-white cursor-pointer transition-all duration-300 ease-in-out`}
+            disabled={isSubmitting || !isPasswordMatch || props?.name === '' || props?.email === '' || props?.companyName === '' || props?.password === ''}
+            className={`w-full rounded-lg ${isSubmitting || !isPasswordMatch || props?.name === '' || props?.email === '' || props?.companyName === '' || props?.password === '' ? 'bg-button-disabled' : 'bg-button hover:bg-button-hover'} px-5 py-2.5 text-center text font-bold text-white cursor-pointer transition-all duration-300 ease-in-out`}
         >
             {text}
         </button>


### PR DESCRIPTION
## 📌 테일윈드 커스텀 수정
• global.css
• 브레이크 포인트 `lg` 추가: 1100px
• 폰트 사이즈 `text-2xs` 확장: 0.5rem
• 전체 페이지 공통 버튼 배경색 & 폰트 컬러, 헤딩 및 디스크립션 컬러
• 추가적으로 `@apply`를 사용해도 되니 다음 리팩토링 때 논의 해보기


## 📌 로그인 폼, 회원가입 폼 상태 관리 및 유효성 검사 로직 리팩토링
• useForm을 사용한 상태 및 메서드 관리