### PR TITLE
[feat] 모임 상세 페이지 퍼블리싱, 네브바 및 페이지 전역 좌우 여백 설정

### DIFF
--- a/src/app/gatherings/detail/[id]/page.tsx
+++ b/src/app/gatherings/detail/[id]/page.tsx
@@ -1,0 +1,123 @@
+import { Heart, Check } from "lucide-react"
+import Image from 'next/image';
+
+export default function GatheringsDetailPage() {
+    return (
+        <>
+            <main className='contents-container'>
+                {/* 이미지, 모임 정보 카드 */}
+                <section className='flex gap-4'>
+                    <div className='relative w-[30rem] h-[14rem]'>
+                        <div className="absolute z-10 top-2 right-2 px-3 py-1 bg-white/80 rounded-full flex items-center text-xs">
+                            <span className="text-main-600 mr-1">🔔</span>
+                            <span className="font-medium text-gray-700">오늘 21시 마감</span>
+                        </div>
+                        <Image src='https://images.unsplash.com/photo-1615793927044-600a1ec42466?q=80&w=2129&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D'
+                            alt='모임 이미지'
+                            width={100}
+                            height={100}
+                            className='w-full h-full object-cover rounded-lg'
+                        />
+                    </div>
+                    <article className='w-[30rem] h-[14rem] px-8 py-10 border-2 border-gray-300 bg-white rounded-lg'
+                    >
+                        {/* 상단 박스 */}
+                        <div className='w-full h-[80%] flex justify-between gap-8'>
+                            {/* LEFT */}
+                            <div className='flex flex-col'>
+                                {/* 제목, 주소 */}
+                                <div className="flex flex-col text-sm">
+                                    <h2 className="text-xl font-bold">달램핏 오피스 스트레칭</h2>
+                                    <span className="text-gray-500">을지로 3가 서울시 중구 청계천로 100</span>
+                                </div>
+                                {/* 날짜 시간 */}
+                                <div className="flex items-center gap-1 text-sm text-gray-500">
+                                    <span>1월 7일</span>
+                                    <span>·</span>
+                                    <span>17:30</span>
+                                </div>
+                                {/* 여백 */}
+                                <div className='w-full h-[3rem]'></div>
+                            </div>
+                            {/* RIGHT 찜하기 버튼 */}
+                            <button className="w-[2.5rem] h-[2.5rem] border-2 border-gray-300 rounded-full flex items-center justify-center text-main-500 cursor-pointer">
+                                <Heart className="w-5 h-5 fill-main-500" />
+                            </button>
+                        </div>
+                        {/* 하단 박스 */}
+                        <div className='flex flex-col gap-1'>
+                            {/* 모집정원, 개설확정 */}
+                            <div className="flex justify-between text-sm">
+                                <div className="flex items-center gap-2">
+                                    <span>모집정원</span>
+                                    <span>12명</span>
+                                    {/* 정원들의 프로필 이미지 */}
+                                </div>
+                                <div className='flex items-center gap-2'>
+                                    <div className='p-1 bg-main-300 rounded-full'>
+                                        <Check className='text-white w-3 h-3' />
+                                    </div>
+                                    <span>개설확정</span>
+                                </div>
+                            </div>
+                            {/* 프로그레스 바 */}
+                            <div className="w-full bg-gray-200 rounded-full h-2">
+                                <div className="bg-main-500 h-2 rounded-full w-[60%]"></div>
+                            </div>
+                            {/* 최소인원, 최대인원 */}
+                            <div className="flex justify-between text-sm">
+                                <span>최소인원 5명</span>
+                                <span>최대인원 20명</span>
+                            </div>
+                        </div>
+                    </article>
+                </section>
+                {/* 모임 리뷰 목록 */}
+                <section className='w-full h-full px-4 py-4 flex flex-col gap-4 bg-white rounded-lg'>
+                    <h1 className='text-lg font-semibold'>다른 참여자들은 이렇게 느꼈어요!</h1>
+                    {/* 아이템 */}
+                    {Array.from({ length: 4 }).map((_, index) => (
+                        <div
+                            key={index}
+                            className='w-full border-dotted border-b-2 border-main-300 flex flex-col gap-2'>
+                            <div className='flex gap-1'>
+                                {Array.from({ length: 5 }).map((_, index) => (
+                                    <Heart key={index} className="w-4 h-4 fill-main-500" />
+                                ))}
+                            </div>
+                            <p className='text-sm'>재밌는 모임이었어요! 다음에도 만나기로 했습니다 ㅋㅋㅋ</p>
+                            <div className='flex items-center gap-1 text-xs'>
+                                <Image src='/images/default_profile_image.svg' alt='프로필 이미지' width={32} height={32} className='rounded-full' />
+                                <span>닉네임</span>
+                                <span>|</span>
+                                <span>2025.05.22</span>
+                            </div>
+                            <div className='w-full h-1'></div>
+                        </div>
+                    ))}
+                    {/* 페이지 컨버터 */}
+                    <div className="flex justify-center items-center gap-2">
+                        <button className="w-8 h-8 flex items-center justify-center text-gray-500 transition">〈</button>
+                        <button className="w-8 h-8 flex items-center justify-center rounded-full border border-main-500 bg-main-500 text-white font-bold">1</button>
+                        <button className="w-8 h-8 flex items-center justify-center rounded-full border border-gray-300 bg-white text-gray-500 hover:bg-main-100 transition">2</button>
+                        <button className="w-8 h-8 flex items-center justify-center rounded-full border border-gray-300 bg-white text-gray-500 hover:bg-main-100 transition">3</button>
+                        <span className="mx-1 text-gray-400">...</span>
+                        <button className="w-8 h-8 flex items-center justify-center rounded-full border border-gray-300 bg-white text-gray-500 hover:bg-main-100 transition">10</button>
+                        <button className="w-8 h-8 flex items-center justify-center text-gray-500 transition">〉</button>
+                    </div>
+                </section>
+            </main >
+            {/* 모임 참가 Footer */}
+            <footer className='sticky bottom-0 w-full h-16 border-t border-gray-300 bg-white rounded-lg'>
+                <div className='max-w-screen-lg h-full mx-auto flex justify-between items-center'>
+                    <div className='flex flex-col gap-1'>
+                        <span className='font-semibold'>모임에 참여해보세요!</span>
+                        <span className='text-xs font-medium'>당신은 모임에 참여해야 합니다.</span>
+                    </div>
+                    <button type="button" className='w-24 h-[60%] bg-button text-button-text rounded-lg cursor-pointer hover:opacity-60 transition duration-300 ease-in'>참여하기</button>
+                </div>
+            </footer>
+        </>
+    );
+}
+

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -186,6 +186,12 @@ html {
   --sidebar-ring: oklch(0.556 0 0);
 }
 
+@layer components {
+  .contents-container {
+    @apply max-w-screen-lg h-screen mx-auto px-20 pt-8 flex flex-col gap-4 bg-neutral-50;
+  }
+}
+
 @layer base {
   * {
     @apply border-border outline-ring/50;

--- a/src/components/gatherings/GatheringsList.tsx
+++ b/src/components/gatherings/GatheringsList.tsx
@@ -1,10 +1,9 @@
 "use client"
 
-
 import { useState, useEffect } from "react";
+import { useRouter } from 'next/navigation';
 import axios from "axios";
 import Image from "next/image";
-
 
 // 모임 목록 인터페이스
 interface Gathering {
@@ -23,18 +22,20 @@ export default function GatheringsList() {
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState('');
     const [gatherings, setGatherings] = useState<Gathering[]>([]);
-    
+
+    const router = useRouter();
+
     // react query로 변경
     const fetchGatherings = async () => {
         try {
             setLoading(true);
             setError('');
             const token = localStorage.getItem('token');
-            
+
             const response = await axios.get('/api/gatherings', {
                 headers: token ? { 'Authorization': `Bearer ${token}` } : {}
             });
-            
+
             setGatherings(response.data);
         } catch {
             setError('모임 목록을 불러오는 중 오류가 발생했습니다.');
@@ -56,26 +57,27 @@ export default function GatheringsList() {
                     <h1>로딩 중...</h1>
                 </div>
             )}
-            
+
             {/* 에러 상태 */}
             {error && (
                 <div className="w-full h-[100px] flex justify-center items-center border-2 border-red-500">
                     <h1 className="text-red-500">{error}</h1>
                 </div>
             )}
-            
+
             {/* 모임 목록 */}
             {!loading && !error && gatherings.map((gathering: Gathering, index: number) => (
-                <div key={gathering.id || index} className="w-full min-h-[100px] flex flex-col justify-start p-4 border-2 border-blue-500 rounded-lg">
+                <button key={gathering.id || index} className="w-full min-h-[100px] flex flex-col text-left p-4 border-2 border-blue-500 rounded-lg cursor-pointer hover:opacity-60"
+                    onClick={() => router.push(`/gatherings/detail/${gathering.id}`)}>
                     <h1 className="text-lg font-semibold">{gathering.name || `모임 ${index + 1}`}</h1>
-                    <Image src={gathering.image} alt="모임 이미지" className="rounded-lg" width={100} height={100}/>
+                    <Image src={gathering.image} alt="모임 이미지" className="rounded-lg" width={100} height={100} />
                     <p className="text-gray-600">위치: {gathering.location}</p>
                     <p className="text-gray-600">종류: {gathering.type}</p>
                     <p className="text-gray-600">참여자: {gathering.participantCount}/{gathering.capacity}명</p>
                     {gathering.dateTime && <p className="text-gray-600">날짜: {new Date(gathering.dateTime).toLocaleDateString()}</p>}
-                </div>
+                </button>
             ))}
-            
+
             {/* 빈 목록 */}
             {!loading && !error && gatherings.length === 0 && (
                 <div className="w-full h-[100px] flex justify-center items-center border-2 border-gray-500">

--- a/src/components/shared/ui/Navbar.tsx
+++ b/src/components/shared/ui/Navbar.tsx
@@ -20,47 +20,47 @@ export default function Navbar() {
     ]
 
     return (
-        <nav
-            className="sticky top-0 z-50 w-full h-[3.75rem] py-8 px-5 lg:px-20 bg-white border-b-2 border-gray-300 flex justify-between text-xs md:text-base font-bold"
-        >
-            <section className='flex gap-4 items-center'>
-                <Link href="/gatherings">
-                    <Image
-                        src="/images/logo.avif"
-                        alt="logo image"
-                        width={100}
-                        height={100}
-                        className='w-[3rem] h-[3rem] md:w-[6rem] md:h-[6rem] pointer-events-none'
-                    />
-                </Link>
-                {navLinks.map(link => {
-                    return (
-                        <Link
-                            key={link.href}
-                            href={link.href}
-                            className={`hover:opacity-50 duration-300 ease-in-out ${pathname.includes(link.href) ? 'text-main-600' : ''}`}
-                        >
-                            {link.label}
-                        </Link>
-                    )
-                })}
-            </section>
-            <section className='flex items-center'>
-                {token && (
-                    <DropdownMenu>
-                        <DropdownMenuTrigger>
-                            <Image src='/images/default_profile_image.svg' alt='profile image' width={32} height={32} className='rounded-full cursor-pointer' />
-                        </DropdownMenuTrigger>
-                        <DropdownMenuContent className='w-[9rem] mt-2 p-2 border-2 border-gray-300 rounded-md bg-white flex flex-col gap-2'>
-                            <DropdownMenuLabel className='text-main-500'>{userName}</DropdownMenuLabel>
-                            <DropdownMenuSeparator className='h-[0.1rem] bg-gray-300' />
-                            <DropdownMenuItem ><Link href='/mypage'>마이페이지</Link></DropdownMenuItem>
-                            <DropdownMenuItem onClick={() => signout()} className='cursor-pointer'>로그아웃</DropdownMenuItem>
-                        </DropdownMenuContent>
-                    </DropdownMenu>
-                )}
-                {!token && <Link href='/login' className='hover:opacity-50 duration-300 ease-in-out'>로그인</Link>}
-            </section>
+        <nav className="sticky z-50 top-0 w-full bg-white border-b-2 border-gray-300 text-xs md:text-base font-bold">
+            <div className="max-w-screen-lg mx-auto h-[3.75rem] py-8 px-5 flex justify-between items-center">
+                <section className='flex gap-4 items-center'>
+                    <Link href="/gatherings">
+                        <Image
+                            src="/images/logo.avif"
+                            alt="logo image"
+                            width={100}
+                            height={100}
+                            className='w-[3rem] h-[3rem] md:w-[6rem] md:h-[6rem] pointer-events-none'
+                        />
+                    </Link>
+                    {navLinks.map(link => {
+                        return (
+                            <Link
+                                key={link.href}
+                                href={link.href}
+                                className={`hover:opacity-50 duration-300 ease-in-out ${pathname.includes(link.href) ? 'text-main-600' : ''}`}
+                            >
+                                {link.label}
+                            </Link>
+                        )
+                    })}
+                </section>
+                <section className='flex items-center'>
+                    {token && (
+                        <DropdownMenu>
+                            <DropdownMenuTrigger>
+                                <Image src='/images/default_profile_image.svg' alt='profile image' width={32} height={32} className='rounded-full cursor-pointer' />
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent className='w-[9rem] mt-2 p-2 border-2 border-gray-300 rounded-md bg-white flex flex-col gap-2'>
+                                <DropdownMenuLabel className='text-main-500'>{userName}</DropdownMenuLabel>
+                                <DropdownMenuSeparator className='h-[0.1rem] bg-gray-300' />
+                                <DropdownMenuItem ><Link href='/mypage'>마이페이지</Link></DropdownMenuItem>
+                                <DropdownMenuItem onClick={() => signout()} className='cursor-pointer'>로그아웃</DropdownMenuItem>
+                            </DropdownMenuContent>
+                        </DropdownMenu>
+                    )}
+                    {!token && <Link href='/login' className='hover:opacity-50 duration-300 ease-in-out'>로그인</Link>}
+                </section>
+            </div>
         </nav>
     );
 }


### PR DESCRIPTION
## 📌 모임 상세 페이지 퍼블리싱
• app/gatherings/detail/[id]/page.tsx
• 피그마 기반 레이아웃과 mock 컨텐츠 사용
• 실제 데이터 바인딩 및 반응형 스타일 적용 필요

## 📌 contents-container 커스텀 클래스 생성
• `@layer`에 정의
• 네브바 좌우여백과 모든 페이지의 콘텐트 컨테이너 좌우여백을 통일
• 다른 팀원들도 해당 커스텀 클래스 네임을 적용시켜야 함