### PR TITLE
[refactor, fix] MyPageUI, MyReviewList 리팩토링 및 queryFn 타입 오류 해결

### DIFF
--- a/src/app/api/gatherings/joined/route.ts
+++ b/src/app/api/gatherings/joined/route.ts
@@ -15,6 +15,7 @@ export async function GET(request: NextRequest) {
 } catch (error) {
     console.error('API 요청 중 오류 발생:', error);
 
+
     if(axios.isAxiosError(error)) {
         if (error.response) {
             console.error('서버 응답 상태:', error.response.status);

--- a/src/app/mypage/ui.tsx
+++ b/src/app/mypage/ui.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useContext } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useSearchParams } from "next/navigation";
 import axios from "axios";
@@ -9,108 +9,116 @@ import ProfileCard from "@/components/mypage/ProfileCard";
 import Meeting from "@/components/mypage/MyMeetingList";
 import MyReviewList from "@/components/mypage/MyReviewList";
 import CreatedMeetingList from "@/components/mypage/CreatedMeetingList";
+import { AuthContext } from "@/providers/AuthProvider";
+
+enum MypageTab {
+  JoinedMeetings = 0,
+  MyReviews = 1,
+  CreatedMeetings = 2,
+}
 
 interface MeetingData {
-    id: string;
-    name: string;
-    image: string;
-    location: string;
-    type: string;
-    participantCount: number;
-    capacity: number;
-    dateTime: string;
-    isCompleted?: boolean;
-    isReviewed?: boolean;
-  }
+  id: string;
+  name: string;
+  image: string;
+  location: string;
+  type: string;
+  participantCount: number;
+  capacity: number;
+  dateTime: string;
+  isCompleted?: boolean;
+  isReviewed?: boolean;
+}
+
+export const fetchJoinedMeetings = async (token: string, queries: string): Promise<MeetingData[]> => {
+  const { data } = await axios.get(`/api/gatherings/joined?${queries}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  return data;
+};
 
 export default function MyPageUI() {
-  const [selectedTab, setSelectedTab] = useState(0);
-  const [isClient, setIsClient] = useState(false); 
+  const [selectedTab, setSelectedTab] = useState<MypageTab>(MypageTab.JoinedMeetings);
   const searchParams = useSearchParams();
   const queries = searchParams.toString();
-  const token = typeof window !== "undefined" ? localStorage.getItem("token") : null;
-
-  useEffect(() => {
-    setIsClient(true); 
-  }, []);
-
-  const fetchJoinedMeetings = async (): Promise<MeetingData[]> => {
-    if (!token) throw new Error("토큰 없음");
-    const { data } = await axios.get(`/api/gatherings/joined?${queries}`, {
-      headers: { Authorization: `Bearer ${token}` },
-    });
-    return data;
-  };
+  const { token } = useContext(AuthContext);
 
   const {
     data: meetings = [],
     isLoading,
     error,
   } = useQuery<MeetingData[], Error>({
-    queryKey: ["joinedMeetings", queries],
-    queryFn: fetchJoinedMeetings,
-    enabled: isClient && selectedTab === 0 && !!token, 
+    queryKey: ["joinedMeetings", queries, token],
+    queryFn: () => fetchJoinedMeetings(token!, queries),
+    enabled: selectedTab === MypageTab.JoinedMeetings && !!token,
   });
 
   return (
-      <div className="bg-gray-50 min-h-screen">
-        <main className="contents-container">
-            <div className="mx-5 pt-[4rem] px-6">
-            <h1 className="text-2xl font-bold text-gray-700 mb-4">마이 페이지</h1>
+      <main className="contents-container">
+        <div className="pt-10 px-6">
+          <h1 className="text-2xl font-bold text-gray-700 mb-4">마이 페이지</h1>
 
-            <div className="border-2 rounded-lg overflow-hidden mb-4">
-                <ProfileCard />
+          <div className="border-2 rounded-lg overflow-hidden mb-4">
+            <ProfileCard />
+          </div>
+
+          {/* 탭 네비게이션 */}
+          <div className="bg-white border-t-[3px] border-gray-800">
+            <div className="pt-8 flex gap-4 text-lg font-bold p-5">
+              {[
+                { label: "나의 모임", value: MypageTab.JoinedMeetings },
+                { label: "나의 리뷰", value: MypageTab.MyReviews },
+                { label: "내가 만든 모임", value: MypageTab.CreatedMeetings },
+              ].map(({ label, value }) => (
+                <button
+                  key={value}
+                  onClick={() => setSelectedTab(value)}
+                  className={`relative pb-2 transition-colors duration-150
+                    ${selectedTab === value
+                      ? "text-gray-800 after:absolute after:-bottom-0.5 after:left-0 after:right-0 after:h-[2px] after:bg-gray-800"
+                      : "text-gray-400"
+                    }`}                  
+                >
+                  {label}
+                </button>
+              ))}
             </div>
 
-            {/* Tab Navigation */}
-            <div className="bg-white border-t-3 border-gray-800">
-                <div className="my-5 flex gap-4 text-xl font-bold p-8">
-                {["나의 모임", "나의 리뷰", "내가 만든 모임"].map((label, idx) => (
-                    <button
-                    key={idx}
-                    onClick={() => setSelectedTab(idx)}
-                    className={
-                        selectedTab === idx
-                        ? "border-gray-700 border-b-3 pb-2 text-gray-700 font-semibold"
-                        : "text-gray-400 font-semibold"
-                    }
-                    >
-                    {label}
-                    </button>
-                ))}
-                </div>
+            {!token && (
+              <div className="w-full h-[100px] flex justify-center items-center text-main-500">
+                토큰 없음
+              </div>
+            )}
 
-                {/* Tab Content */}
-                {isClient && selectedTab === 0 && (
-                <div className="w-full flex flex-col gap-5">
-                    {isLoading && (
-                    <div className="w-full h-[100px] flex justify-center items-center border-2 border-blue-500">
-                        <h1>로딩 중...</h1>
-                    </div>
-                    )}
-                    {error && (
-                    <div className="w-full h-[100px] flex justify-center items-center border-2 border-red-500">
-                        <h1 className="text-red-500">{error.message || "오류 발생"}</h1>
-                    </div>
-                    )}
-                    {!isLoading &&
-                    !error &&
-                    meetings.map((meeting) => (
-                        <Meeting key={meeting.id} data={meeting} />
-                    ))}
-                    {!isLoading && !error && meetings.length === 0 && (
-                    <div className="w-full h-[100px] flex justify-center items-center border-2 border-gray-500">
-                        <h1>참석한 모임이 없습니다.</h1>
-                    </div>
-                    )}
-                </div>
+            {token && selectedTab === MypageTab.JoinedMeetings && (
+              <div className="w-full flex flex-col gap-5">
+                {isLoading && (
+                  <div className="w-full h-[100px] flex justify-center items-center border-2 border-blue-500">
+                    <h1>로딩 중...</h1>
+                  </div>
                 )}
+                {error && (
+                  <div className="w-full h-[100px] flex justify-center items-center border-2 border-red-500">
+                    <h1 className="text-red-500">{error.message || "오류 발생"}</h1>
+                  </div>
+                )}
+                {!isLoading &&
+                  !error &&
+                  meetings.map((meeting) => (
+                    <Meeting key={meeting.id} data={meeting} />
+                  ))}
+                {!isLoading && !error && meetings.length === 0 && (
+                  <div className="w-full h-[100px] flex justify-center items-center border-2 border-gray-500">
+                    <h1>참석한 모임이 없습니다.</h1>
+                  </div>
+                )}
+              </div>
+            )}
 
-                {selectedTab === 1 && <MyReviewList/>}
-                {selectedTab === 2 && <CreatedMeetingList />}
-            </div>
-            </div>
-        </main>
-      </div>
+            {token && selectedTab === MypageTab.MyReviews && <MyReviewList />}
+            {token && selectedTab === MypageTab.CreatedMeetings && <CreatedMeetingList />}
+          </div>
+        </div>
+      </main>
   );
 }

--- a/src/components/gatherings/CreateMeetingModal.tsx
+++ b/src/components/gatherings/CreateMeetingModal.tsx
@@ -183,6 +183,7 @@ export default function CreateMeetingModal({ onClose }: { onClose: () => void })
                 <form 
                     className="flex flex-col md:w-xl w-full h-full md:m-auto p-5 bg-white md:rounded-lg"
                     onSubmit={handleSubmit}
+            
                 >
                     {/* 모임 만들기 타이틀 */}
                     <div className="w-full h-[50px] bg-white rounded-lg flex flex-row justify-between items-center mb-5">
@@ -292,7 +293,7 @@ export default function CreateMeetingModal({ onClose }: { onClose: () => void })
                             />
                         </div>
                     </div>
-                    
+
                     {/* 모집정원 */}
                     <div className="w-full mb-5">
                         <h1 className="font-bold text-gray-800 mb-3">모집 정원</h1>

--- a/src/components/mypage/MyMeetingList.tsx
+++ b/src/components/mypage/MyMeetingList.tsx
@@ -41,7 +41,8 @@ export default function Meeting({ data }: MeetingProps) {
           alt={`${name} 이미지`}
           width={100}
           height={100}
-          className="rounded-lg object-cover my-2"
+          className="rounded-lg object-cover my-2 pointer-events-none"
+          
         />
       )}
 

--- a/src/components/mypage/MyReviewList.tsx
+++ b/src/components/mypage/MyReviewList.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
-import { useState, useEffect } from "react";
+import { useState, useContext } from "react";
 import { useRouter } from 'next/navigation';
 import axios from "axios";
 import Image from "next/image";
+import { AuthContext } from "@/providers/AuthProvider";
 
 interface Gathering {
   id: string;
@@ -21,21 +22,14 @@ interface Gathering {
 
 export default function MyReviewList() {
   const [reviews, setReviews] = useState(0);
-  const [isClient, setIsClient] = useState(false);
+  const { token } = useContext(AuthContext);
   const router = useRouter();
 
-  useEffect(() => {
-    setIsClient(true);
-  }, []);
 
-  const token = typeof window !== "undefined" ? localStorage.getItem("token") : null;
-
-  const fetchGatherings = async () => {
-    if (!token) throw new Error("토큰 없음");
-    const { data } = await axios.get("/api/gatherings/joined", {
+  const fetchGatherings = (token: string): Promise<Gathering[]> => {
+    return axios.get("/api/gatherings/joined", {
       headers: { Authorization: `Bearer ${token}` },
-    });
-    return data;
+    }).then(res => res.data);
   };
 
   const {
@@ -43,19 +37,17 @@ export default function MyReviewList() {
     isLoading,
     error,
   } = useQuery<Gathering[], Error>({
-    queryKey: ["myReviewGatherings"],
-    queryFn: fetchGatherings,
-    enabled: isClient && !!token,
+    queryKey: ["myReviewGatherings", token],
+    queryFn: () => fetchGatherings(token!),
+    enabled: !!token,
   });
 
   const reviewedGatherings = gatherings.filter((g) => g.isReviewed);
   const writableGatherings = gatherings.filter((g) => !g.isReviewed);
-
-  const isEmpty =
-    (reviews === 0 && writableGatherings.length === 0) ||
-    (reviews === 1 && reviewedGatherings.length === 0);
-
   const list = reviews === 0 ? writableGatherings : reviewedGatherings;
+
+  const isSuccess = !isLoading && !error;
+  const isEmpty = isSuccess && list.length === 0;
 
   return (
     <div className="w-full flex flex-col justify-start gap-5">

--- a/src/components/mypage/ProfileCard.tsx
+++ b/src/components/mypage/ProfileCard.tsx
@@ -25,13 +25,13 @@ export default function ProfileCard() {
         <div className="text-gray-800 text-lg font-bold mb-1">내 프로필</div>
         <div className="absolute right-4 top-4">
           <button>
-            <Image src="/icons/edit.svg" alt="프로필 수정" width={36} height={36} />
+            <Image src="/icons/edit.svg" alt="프로필 수정" width={36} height={36} className="pointer-events-none"/>
           </button>
         </div>
         {/*Background */}
         <div className="h-2 mt-2 relative">
           <div className="absolute bottom-0 right-20 flex items-end justify-end w-[120px] h-full">
-            <Image src="/icons/bg.svg" alt="배경" width={120} height={120} />
+            <Image src="/icons/bg.svg" alt="배경" width={120} height={120} className="pointer-events-none"/>
           </div>
         </div>
       </div>
@@ -40,7 +40,7 @@ export default function ProfileCard() {
       <div className="bg-white p-4 flex items-center h-full">
         <div className="border-gray-100 rounded-full p-0.5 mr-4 -mt-16 z-1">
           <button>
-            <Image src="/icons/profile.svg" alt="프로필" width={63} height={63} />
+            <Image src="/icons/profile.svg" alt="프로필" width={63} height={63} className="pointer-events-none" />
           </button>
         </div>
         <div>


### PR DESCRIPTION
## 📌 [refactor] MyPageUI에서 token 관리 구조 개선
• MyPageUI.tsx
• localStorage로 token을 가져오던 기존 방식 제거
• useContext(AuthContext)를 통해 안전하게 token 참조
• isClient 상태 제거 및 queryKey 안정화 (token 포함)

## 📌 [refactor] MyReviewList에서 React Query 구조 개선
• MyReviewList.tsx
• localStorage token 제거 → useContext(AuthContext)로 전환
• queryFn 내부에서 token 인자 받도록 변경
• queryKey에 token 포함하여 캐시 안정성 확보

## 📌 [fix] queryFn 타입 오류 
• MyReviewList.tsx 
• 원인: queryFn에 인자(token)를 직접 전달하면서 타입 에러 발생
• 해결: queryFn 내부에서 클로저 처리 또는 queryKey 기반으로 token 추출하여 전달
