### PR TITLE
[feat, rename] 서버 사이드 모임 목록 삭제시 리렌더 트리거 구현, hooks 함수 표현식 변경

### DIFF
--- a/src/app/gatherings/detail/[id]/ui.tsx
+++ b/src/app/gatherings/detail/[id]/ui.tsx
@@ -2,16 +2,16 @@
 
 import { use, useContext, useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { useFetchGatheringDetail } from '@/hooks/gathering/useFetchGatheringDetail';
+import { useCheckJoined } from '@/hooks/gathering/useCheckJoined';
+import { useJoinGathering } from '@/hooks/gathering/useJoinGathering';
+import { useCancelGathering } from '@/hooks/gathering/useCancelGathering';
+import { useLeaveGathering } from '@/hooks/gathering/useLeaveGathering';
 import { AuthContext } from '@/providers/AuthProvider';
 import { formatDate, formatTime, getTimeRemaining } from '@/components/shared/utils/format';
 import { Heart, Check, UserRoundCheck } from "lucide-react"
 import { PageProps } from '@/types/pageProps';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import useFetchGatheringDetail from '@/hooks/gathering/useFetchGatheringDetail';
-import useCheckJoined from '@/hooks/gathering/useCheckJoined';
-import useJoinGathering from '@/hooks/gathering/useJoinGathering';
-import useLeaveGathering from '@/hooks/gathering/useLeaveGathering';
-import useCancelGathering from '@/hooks/gathering/useCancelGathering';
 import Image from 'next/image';
 import CheckingModal from '@/components/shared/ui/ConfirmDialog';
 import SaveToggleButton from '@/components/gatherings/shared/ui/SaveToggleButton';

--- a/src/app/gatherings/page.tsx
+++ b/src/app/gatherings/page.tsx
@@ -1,5 +1,5 @@
-import Gatherings from "@/components/gatherings/gatherings";
 import { Gathering } from "@/types/gatherings";
+import Gatherings from "@/components/gatherings/gatherings";
 
 async function getInitialGatherings(): Promise<Gathering[]> {
     try {
@@ -13,7 +13,7 @@ async function getInitialGatherings(): Promise<Gathering[]> {
 
         if (!response.ok) {
             const errorText = await response.text();
-            console.error('SSR API 실패:', {
+            console.error('모임 목록 데이터 SSR 실패:', {
                 status: response.status,
                 statusText: response.statusText,
                 body: errorText
@@ -23,10 +23,7 @@ async function getInitialGatherings(): Promise<Gathering[]> {
 
         const data = await response.json();
 
-        // console.log(data);
-
         if (Array.isArray(data)) {
-            // console.log('SSR 데이터:', data.length, '개');
             return data;
         } else {
             console.warn('응답이 배열이 아닙니다:', data);

--- a/src/app/saved/ui.tsx
+++ b/src/app/saved/ui.tsx
@@ -6,7 +6,7 @@ import Image from "next/image";
 import { Heart } from 'lucide-react';
 import { Gathering } from "@/types/gatherings";
 import { AuthContext } from '@/providers/AuthProvider';
-import { useSavedGatherings } from "@/hooks/gathering/useSavedGatherings";
+import { useSavedGatherings } from "@/hooks/gathering/useToggleSavedGatherings";
 import { formatDate, formatTime, getTimeRemaining } from "@/components/shared/utils/format";
 import axios from 'axios';
 

--- a/src/components/gatherings/CreateGatheringDialog.tsx
+++ b/src/components/gatherings/CreateGatheringDialog.tsx
@@ -2,11 +2,11 @@
 
 import { AuthContext } from '@/providers/AuthProvider';
 import { useState, useRef, useEffect, useContext } from "react";
+import { useCreateGathering } from '@/hooks/gathering/useCreateGathering';
 import { XIcon } from "lucide-react";
 import SelectionService from "./SelectionService";
 import DatePicker from "react-datepicker";
 import axios from "axios";
-import useMakeGathering from '@/hooks/gathering/useCreateGathering';
 import "react-datepicker/dist/react-datepicker.css";
 
 export default function CreateGatheringDialog({ onClose }: { onClose: () => void }) {
@@ -39,7 +39,7 @@ export default function CreateGatheringDialog({ onClose }: { onClose: () => void
 
     const { token } = useContext(AuthContext);
 
-    const { makeGathering } = useMakeGathering(token);
+    const { createGathering } = useCreateGathering(token);
 
     // 입력 필드 변경 핸들러
     const handleInputChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
@@ -166,9 +166,8 @@ export default function CreateGatheringDialog({ onClose }: { onClose: () => void
             }
 
             // 모임 생성
-            const response = makeGathering(apiFormData);
-            console.log(response);
-            onClose();
+            const response = createGathering(apiFormData);
+            if (response!) onClose();
         } catch (error) {
             console.error('API 요청 중 오류 발생:', error);
 

--- a/src/components/gatherings/Gatherings.tsx
+++ b/src/components/gatherings/Gatherings.tsx
@@ -1,7 +1,8 @@
 "use client"
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Gathering } from "@/types/gatherings";
+import { useGatheringsStore } from '@/store/gatheringsStore';
 import CreateMeetingModal from "@/components/gatherings/CreateGatheringDialog";
 import GatheringsList from "@/components/gatherings/GatheringsList";
 import Image from "next/image";
@@ -12,6 +13,11 @@ interface PageProps {
 
 export default function Gatherings({ initialGatherings = [] }: PageProps) {
     const [isModalOpen, setIsModalOpen] = useState(false);
+    const setGatherings = useGatheringsStore((s) => s.setGatherings);
+
+    useEffect(() => {
+        setGatherings(initialGatherings);
+    }, [initialGatherings, setGatherings]);
 
     const openModal = () => setIsModalOpen(true);
     const closeModal = () => setIsModalOpen(false);
@@ -74,7 +80,6 @@ export default function Gatherings({ initialGatherings = [] }: PageProps) {
                 </div>
                 {/* SSR 데이터를 GatheringsList에 전달 */}
                 <GatheringsList
-                    gatherings={initialGatherings}
                     fetchFromApi={true}
                 />
             </div>

--- a/src/components/gatherings/GatheringsList.tsx
+++ b/src/components/gatherings/GatheringsList.tsx
@@ -1,7 +1,8 @@
 "use client"
 
 import { useRouter } from "next/navigation";
-import { useInfiniteGatherings } from "@/hooks/gathering/useInfiniteGatherings";
+import { useFetchInfiniteGatherings } from "@/hooks/gathering/useFetchInfiniteGatherings";
+import { useGatheringsStore } from '@/store/gatheringsStore';
 import { Gathering, GatheringsListProps } from "@/types/gatherings"; // 경로 변경
 import { formatDate, formatTime, getTimeRemaining } from '@/components/shared/utils/format'; // format 함수 import
 import { UserRoundCheck } from "lucide-react"
@@ -9,30 +10,30 @@ import Image from "next/image";
 import SaveToggleButton from "@/components/gatherings/shared/ui/SaveToggleButton";
 import JoinedCountsProgressBar from './shared/ui/JoinedCountsProgressBar';
 
-// 모임 목록 컴포넌트
 export default function GatheringsList({
-    gatherings: propGatherings = [],
-    fetchFromApi = true
+    fetchFromApi = true,
 }: GatheringsListProps) {
     const router = useRouter();
 
-    // SSR 데이터 확인
-    const hasSSRData = propGatherings.length > 0;
+    // 전역 상태: SSR 모임 목록
+    const ssrGatherings = useGatheringsStore((s) => s.gatherings);
 
-    // 무한스크롤 쿼리 
+    // SSR 모임 목록 확인
+    const hasSSRData = ssrGatherings.length > 0;
+
     const {
         infiniteGatherings,
         lastItemRef,
         isFetchingNextPage,
         infiniteScrollEnabled,
-    } = useInfiniteGatherings({
+    } = useFetchInfiniteGatherings({
         enabled: fetchFromApi,
         hasSSRData,
     });
 
     // 전체 모임 데이터 합치기
-    const allGatherings = (() => {
-        const gatherings = [...propGatherings];
+    const mergedGatherings = (() => {
+        const gatherings = [...ssrGatherings];
 
         if (hasSSRData && fetchFromApi && infiniteScrollEnabled) {
             gatherings.push(...infiniteGatherings);
@@ -43,11 +44,10 @@ export default function GatheringsList({
 
     // 최종 모임 목록
     const finalGatherings = fetchFromApi
-        ? (hasSSRData ? allGatherings : [])  // 메인 페이지: SSR + 무한스크롤
-        : propGatherings;                    // 찜목록: 전달받은 데이터 그대로
+        ? (hasSSRData ? mergedGatherings : [])  // 메인 페이지: SSR + 무한스크롤
+        : ssrGatherings;                    // 찜목록: 전달받은 데이터 그대로
 
     const isInitialLoading = fetchFromApi && !hasSSRData;
-
 
     return (
         <div className="w-full flex flex-col justify-start gap-5">

--- a/src/components/gatherings/shared/ui/SaveToggleButton.tsx
+++ b/src/components/gatherings/shared/ui/SaveToggleButton.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import React from 'react';
-import { useSavedGatherings } from "@/hooks/gathering/useSavedGatherings";
+import { useToggleSavedGatherings } from "@/hooks/gathering/useToggleSavedGatherings";
 
 interface SaveToggleButtonProps {
     gatheringId: string;
@@ -19,7 +19,7 @@ export default function SaveToggleButton({
     gatheringId,
     className = ''
 }: SaveToggleButtonProps) {
-    const { savedIds, toggleSaved, isToggling } = useSavedGatherings();
+    const { savedIds, toggleSaved, isToggling } = useToggleSavedGatherings();
     const isSaved = savedIds.includes(gatheringId);
 
     return (

--- a/src/hooks/gathering/useCancelGathering.ts
+++ b/src/hooks/gathering/useCancelGathering.ts
@@ -1,3 +1,4 @@
+import { useGatheringsStore } from '@/store/gatheringsStore';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import axios from 'axios';
 
@@ -11,16 +12,18 @@ interface UseCancelGatheringProps {
 * @param onErrorCallback 에러 콜백 함수 (모달에 표시할 메세지를 전달 받음)
 * @returns {function} cancelGathering - 모임 삭제 함수
 */
-export default function useCancelGathering({ token, onErrorCallback }: UseCancelGatheringProps) {
+export const useCancelGathering = ({ token, onErrorCallback }: UseCancelGatheringProps) => {
     const queryClient = useQueryClient();
+    const removeGathering = useGatheringsStore((s) => s.removeGathering);
 
     const cancelGathering = useMutation({
         mutationFn: async (id: number) => {
             if (!token) throw new Error('로그인이 필요합니다.');
-            const response = await axios.put(`/api/gatherings/cancel?id=${id}`, {}, { headers: { Authorization: `Bearer ${token}` } });
-            return response.data;
+            await axios.put(`/api/gatherings/cancel?id=${id}`, {}, { headers: { Authorization: `Bearer ${token}` } });
+            return id;
         },
-        onSuccess: () => {
+        onSuccess: (id) => {
+            removeGathering(id);
             queryClient.invalidateQueries({ queryKey: ['gatherings', 'infinite'] });
             alert('모임을 삭제했습니다.');
         },

--- a/src/hooks/gathering/useCheckJoined.ts
+++ b/src/hooks/gathering/useCheckJoined.ts
@@ -8,10 +8,10 @@ import axios from 'axios';
  * @param id
  * @returns {data(boolean 타입), isLoading, isError}
  */
-export default function useGatheringJoinCheckingQuery(
+export const useCheckJoined = (
     id: number,
     token: string | null
-) {
+) => {
     const searchParams = useSearchParams();
     const queries = searchParams.toString();
 

--- a/src/hooks/gathering/useCreateGathering.ts
+++ b/src/hooks/gathering/useCreateGathering.ts
@@ -1,10 +1,15 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import axios from 'axios';
 
-export default function useMakeGathering(token: string | null) {
+/**
+ * 모임 생성 훅
+ * @param token 토큰
+ * @returns {function} createGathering - 모임 생성 함수
+ */
+export const useCreateGathering = (token: string | null) => {
     const queryClient = useQueryClient();
 
-    const makeGathering = useMutation({
+    const createGathering = useMutation({
         mutationFn: async (formData: FormData) => {
             if (!token) throw new Error('로그인이 필요합니다.');
             const response = await axios.post(`/api/gatherings`, formData, {
@@ -29,5 +34,5 @@ export default function useMakeGathering(token: string | null) {
         }
     });
 
-    return { makeGathering: makeGathering.mutate }
+    return { createGathering: createGathering.mutate }
 }

--- a/src/hooks/gathering/useCreateReview.ts
+++ b/src/hooks/gathering/useCreateReview.ts
@@ -11,7 +11,7 @@ interface UseJoinGatheringProps {
 * @param onErrorCallback 에러 콜백 함수 (모달에 표시할 메세지를 전달 받음)
 * @returns {function} joinGathering - 모임 참가 함수
 */
-export default function useCreateReview({ token, onErrorCallback }: UseJoinGatheringProps) {
+export const useCreateReview = ({ token, onErrorCallback }: UseJoinGatheringProps) => {
     const queryClient = useQueryClient();
 
     const joinGathering = useMutation({

--- a/src/hooks/gathering/useFetchDetailReview.ts
+++ b/src/hooks/gathering/useFetchDetailReview.ts
@@ -6,9 +6,9 @@ import axios from 'axios';
  * @param id
  * @returns {data, isLoading, isError}
  */
-export default function useGatheringReviewQuery(
+export const useGatheringReviewQuery = (
     id: number
-) {
+) => {
     const fetchGatheringReviews = async (id: number) => {
         try {
             const response = await axios.get(`/api/gatherings/detail/reviews?id=${id}`);

--- a/src/hooks/gathering/useFetchGatheringDetail.ts
+++ b/src/hooks/gathering/useFetchGatheringDetail.ts
@@ -6,9 +6,9 @@ import axios from 'axios';
  * @param id
  * @returns {data, isLoading, isError}
  */
-export default function useGatheringDetail(
+export const useFetchGatheringDetail = (
     id: number
-) {
+) => {
     const queryClient = useQueryClient();
 
     const fetchGatheringDetail = async (id: number) => {

--- a/src/hooks/gathering/useFetchInfiniteGatherings.ts
+++ b/src/hooks/gathering/useFetchInfiniteGatherings.ts
@@ -3,7 +3,7 @@ import { useInfiniteQuery } from '@tanstack/react-query';
 import { fetchGatheringsPaginated } from '@/components/gatherings/shared/utils/fetch';
 import { AuthContext } from '@/providers/AuthProvider';
 
-interface UseInfiniteGatheringsProps {
+interface UseFetchInfiniteGatheringsProps {
     enabled: boolean; // 무한스크롤 활성화 여부
     hasSSRData: boolean; // SSR 데이터 존재 여부
 }
@@ -14,7 +14,7 @@ interface UseInfiniteGatheringsProps {
  * @param hasSSRData SSR 데이터 존재 여부
  * @returns 
  */
-export const useInfiniteGatherings = ({ enabled, hasSSRData }: UseInfiniteGatheringsProps) => {
+export const useFetchInfiniteGatherings = ({ enabled, hasSSRData }: UseFetchInfiniteGatheringsProps) => {
     const { token } = useContext(AuthContext);
     const observerRef = useRef<IntersectionObserver | null>(null);
     const [infiniteScrollEnabled, setInfiniteScrollEnabled] = useState(false);

--- a/src/hooks/gathering/useJoinGathering.ts
+++ b/src/hooks/gathering/useJoinGathering.ts
@@ -11,7 +11,7 @@ interface UseJoinGatheringProps {
 * @param onErrorCallback 에러 콜백 함수 (모달에 표시할 메세지를 전달 받음)
 * @returns {function} joinGathering - 모임 참가 함수
 */
-export default function useJoinGathering({ token, onErrorCallback }: UseJoinGatheringProps) {
+export const useJoinGathering = ({ token, onErrorCallback }: UseJoinGatheringProps) => {
     const queryClient = useQueryClient();
 
     const joinGathering = useMutation({

--- a/src/hooks/gathering/useLeaveGathering.ts
+++ b/src/hooks/gathering/useLeaveGathering.ts
@@ -11,7 +11,7 @@ interface UseLeaveGatheringProps {
 * @param onErrorCallback 에러 콜백 함수 (모달에 표시할 메세지를 전달 받음)
 * @returns {function} leaveGathering - 모임 참여 취소 함수
 */
-export default function useLeaveGathering({ token, onErrorCallback }: UseLeaveGatheringProps) {
+export const useLeaveGathering = ({ token, onErrorCallback }: UseLeaveGatheringProps) => {
     const queryClient = useQueryClient();
 
     const leaveGathering = useMutation({

--- a/src/hooks/gathering/useToggleSavedGatherings.ts
+++ b/src/hooks/gathering/useToggleSavedGatherings.ts
@@ -8,7 +8,7 @@ import { getSavedGatherings, setSavedGatherings } from "@/components/gatherings/
  * @returns {function} toggleSaved - 찜한 모임 토글 기능
  * @returns {boolean} isToggling - 찜한 모임 토글 기능 진행 중 여부
  */
-export const useSavedGatherings = () => {
+export const useToggleSavedGatherings = () => {
     const queryClient = useQueryClient();
 
     // 찜목록 조회

--- a/src/store/gatheringsStore.ts
+++ b/src/store/gatheringsStore.ts
@@ -1,0 +1,23 @@
+import { create } from 'zustand';
+import { Gathering } from '@/types/gatherings';
+
+/**
+ * SSR 모임 목록
+ * @type {Gathering[]} gatherings 모임 목록
+ * @type {function} setGatherings 모임 목록 설정 함수
+ * @type {function} removeGathering 모임 삭제 함수
+ */
+interface GatheringsState {
+    gatherings: Gathering[];
+    setGatherings: (gatherings: Gathering[]) => void;
+    removeGathering: (id: number) => void;
+}
+
+export const useGatheringsStore = create<GatheringsState>((set) => ({
+    gatherings: [],
+    setGatherings: (gatherings) => set({ gatherings }),
+    removeGathering: (id) =>
+        set((state) => ({
+            gatherings: state.gatherings.filter((g) => g.id !== id),
+        })),
+}));


### PR DESCRIPTION
## 📌 서버 사이드 모임 목록 삭제시 리렌더 트리거 구현
• gatheringsStore.ts
• Zustand로 `app/gatherings/page.tsx`에서 넘겨주는 초기 모임 목록을 Gatherings에서 받고 바로 useGatheringsStore.gatherings로 저장
• useCancelGathering에서 onSuccess일 때 useGatheringsStore.removeGathering으로 상태를 삭제하여 지우는 방식으로 해결

## 📌 `/hooks` 함수 표현식 변경
• export const 훅명 = () => {};